### PR TITLE
Fix binary hash, update docker instructions and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+FROM docker.io/rust@sha256:8463cc29a3187a10fc8bf5200619aadf78091b997b0c3941345332a931c40a64
+WORKDIR /app
+COPY . .
+RUN cargo build --release --locked --target=x86_64-unknown-linux-musl
+
 FROM docker.io/alpine@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e9796141b1d379ae
-COPY target/x86_64-unknown-linux-musl/release/asdf /asdf
+COPY --from=0 /app/target/x86_64-unknown-linux-musl/release/asdf /asdf
 ENTRYPOINT ["/asdf"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 build:
 	docker run --rm -v "$(PWD):/app" -w /app -u "$(shell id -u):$(shell id -g)" \
-		rust@sha256:8463cc29a3187a10fc8bf5200619aadf78091b997b0c3941345332a931c40a64
+		rust@sha256:8463cc29a3187a10fc8bf5200619aadf78091b997b0c3941345332a931c40a64 \
 		cargo build --release --locked --target=x86_64-unknown-linux-musl
 
 docker:

--- a/README.md
+++ b/README.md
@@ -133,43 +133,48 @@ you built yourself.
 ### Reproducing the Docker image
 
 There's a Dockerfile in the repository that always produces the same
-bit-for-bit identical image if we provide the same binary (and use the right
-command). It does so by selecting one specific official alpine image by its
-sha256 hash, then `COPY`s the binary we've built in the previous section.
+bit-for-bit identical image. It's a multi-stage build, so it builds the binary
+in one temporary image and then creates the real image with just `FROM`, `COPY`
+and `ENTRYPOINT`. The build environment is virtually identical to what we're
+using in the previous section, then we're copying it over into an Alpine image
+that's pinned by its sha256 hash.
 
 ```sh
-$ b2sum target/x86_64-unknown-linux-musl/release/asdf
-35578eb5fbd13fe27bbc9f799488de2a196acfdb00886d7a5b88e13e0a73e8197fded1afdc9eb6b886864cd39bdeaa17910351da971710056630b1cb3a31a8cd  target/x86_64-unknown-linux-musl/release/asdf
 $ make docker
 sudo buildah bud --timestamp 0 --tag asdf
-STEP 1/3: FROM docker.io/alpine@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e9796141b1d379ae
-STEP 2/3: COPY target/x86_64-unknown-linux-musl/release/asdf /asdf
-STEP 3/3: ENTRYPOINT ["/asdf"]
-COMMIT asdf
+[1/2] STEP 1/4: FROM docker.io/rust@sha256:8463cc29a3187a10fc8bf5200619aadf78091b997b0c3941345332a931c40a64
+[1/2] STEP 2/4: WORKDIR /app
+[1/2] STEP 3/4: COPY . .
+[1/2] STEP 4/4: RUN cargo build --release --locked --target=x86_64-unknown-linux-musl
+    Finished release [optimized] target(s) in 0.02s
+[2/2] STEP 1/3: FROM docker.io/alpine@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e9796141b1d379ae
+[2/2] STEP 2/3: COPY --from=0 /app/target/x86_64-unknown-linux-musl/release/asdf /asdf
+[2/2] STEP 3/3: ENTRYPOINT ["/asdf"]
+[2/2] COMMIT asdf
 Getting image source signatures
 Copying blob bc276c40b172 skipped: already exists
-Copying blob 0ab66dfcdb16 done
-Copying config 1816fbf1a0 done
+Copying blob 358fb8c18c87 [--------------------------------------] 0.0b / 0.0b
+Copying config 950be5f14e done
 Writing manifest to image destination
 Storing signatures
---> 1816fbf1a0d
+--> 950be5f14ef
 Successfully tagged localhost/asdf:latest
-1816fbf1a0d2b49dda1eecc604419e5a8cb72df7924a7d2a3ebded128c9a1f66
+950be5f14efbb7f9cccd40e71560a9e150de4717e47af8933b35d6c89c8f9e83
 ```
 
 The last line is the hash of our image.  We're using buildah to build the image
 because there's no way to set the layer timestamp with docker (causing the hash
 to vary). Unfortunately buildah records it's version, this image has been built
-with `1.22.0`.
+with `1.22.3`.
 
 Next pull the image from the registry:
 
 ```sh
 $ docker pull ghcr.io/kpcyrd/i-probably-didnt-backdoor-this:latest
 latest: Pulling from kpcyrd/i-probably-didnt-backdoor-this
-06127b9e1ec2: Pull complete
-7c4fdf312986: Pull complete
-Digest: sha256:7914eb02bce9944273a753e83cd55063ddbfd1aaf76fc023175188485d968fd3
+50341f5fa632: Pull complete
+728be0271f95: Pull complete
+Digest: sha256:fb3bf3c27010d68bdbfe66d0953b447db7dc097717df7d86e285a501e6c992da
 Status: Downloaded newer image for ghcr.io/kpcyrd/i-probably-didnt-backdoor-this:latest
 ghcr.io/kpcyrd/i-probably-didnt-backdoor-this:latest
 ```
@@ -177,10 +182,10 @@ ghcr.io/kpcyrd/i-probably-didnt-backdoor-this:latest
 You'll noticed the hash doesn't seem to match at first, but the image id is
 indeed the same:
 
-```
+```sh
 $ docker images --no-trunc ghcr.io/kpcyrd/i-probably-didnt-backdoor-this
 REPOSITORY                                      TAG       IMAGE ID                                                                  CREATED        SIZE
-ghcr.io/kpcyrd/i-probably-didnt-backdoor-this   latest    sha256:1816fbf1a0d2b49dda1eecc604419e5a8cb72df7924a7d2a3ebded128c9a1f66   51 years ago   9.38MB
+ghcr.io/kpcyrd/i-probably-didnt-backdoor-this   latest    sha256:950be5f14efbb7f9cccd40e71560a9e150de4717e47af8933b35d6c89c8f9e83   51 years ago   9.38MB
 ```
 
 ### Reproducing the Arch Linux package
@@ -209,7 +214,7 @@ The following places need to be updated occasionally, causing the artifact
 hashes to change.
 
 - Dependencies in Cargo.toml/Cargo.lock (if any, cargo update)
-- `FROM` line in Dockerfile (docker pull alpine:latest)
+- `FROM` lines in Dockerfile (docker pull rust:alpine, docker pull alpine:latest)
 - The build image in the Makefile (docker pull rust:alpine)
 
 ### How is this related to Reproducible Builds

--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ $ b2sum target/x86_64-unknown-linux-musl/release/asdf
 abdac109cfe060fdf59e7196b11b39be623da148cb03fe47973edab5f28a708ab2bfe02a1785c0a907d0cb3d1cb4d7baf66d155b317af9b0452fb9cb1de895a9  target/x86_64-unknown-linux-musl/release/asdf
 ```
 
+Downloading and hashing the pre-compiled binary from the [releases
+page](https://github.com/kpcyrd/i-probably-didnt-backdoor-this/releases) should
+give you an identical hash:
+
+```sh
+$ curl -LsS 'https://github.com/kpcyrd/i-probably-didnt-backdoor-this/releases/download/v0.1.0/asdf' | b2sum -
+abdac109cfe060fdf59e7196b11b39be623da148cb03fe47973edab5f28a708ab2bfe02a1785c0a907d0cb3d1cb4d7baf66d155b317af9b0452fb9cb1de895a9  -
+```
+
 If you get the same checksum you've successfully reproduced the binary. If
 there's no difference between the pre-compiled binary and the one you built
 yourself this means the pre-compiled binary is just as trustworthy as the one
@@ -162,12 +171,14 @@ Successfully tagged localhost/asdf:latest
 950be5f14efbb7f9cccd40e71560a9e150de4717e47af8933b35d6c89c8f9e83
 ```
 
-The last line is the hash of our image.  We're using buildah to build the image
-because there's no way to set the layer timestamp with docker (causing the hash
-to vary). Unfortunately buildah records it's version, this image has been built
-with `1.22.3`.
+The last line is the hash of the image we just built. We're using buildah to
+build the image because there's no way to set the layer timestamp with docker
+(causing the hash to vary). Unfortunately buildah records it's version, this
+image has been built with `1.22.3`.
 
-Next pull the image from the registry:
+The pre-compiled images can be found on the [container
+registry](https://github.com/kpcyrd/i-probably-didnt-backdoor-this/pkgs/container/i-probably-didnt-backdoor-this)
+(also linked in the side-bar on the right). Pull the image with this command:
 
 ```sh
 $ docker pull ghcr.io/kpcyrd/i-probably-didnt-backdoor-this:latest
@@ -179,8 +190,8 @@ Status: Downloaded newer image for ghcr.io/kpcyrd/i-probably-didnt-backdoor-this
 ghcr.io/kpcyrd/i-probably-didnt-backdoor-this:latest
 ```
 
-You'll noticed the hash doesn't seem to match at first, but the image id is
-indeed the same:
+You'll noticed the hash doesn't seem to match at first, but if everything
+worked the image id is indeed the same:
 
 ```sh
 $ docker images --no-trunc ghcr.io/kpcyrd/i-probably-didnt-backdoor-this

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ this checksum:
 
 ```sh
 $ b2sum target/x86_64-unknown-linux-musl/release/asdf
-35578eb5fbd13fe27bbc9f799488de2a196acfdb00886d7a5b88e13e0a73e8197fded1afdc9eb6b886864cd39bdeaa17910351da971710056630b1cb3a31a8cd  target/x86_64-unknown-linux-musl/release/asdf
+abdac109cfe060fdf59e7196b11b39be623da148cb03fe47973edab5f28a708ab2bfe02a1785c0a907d0cb3d1cb4d7baf66d155b317af9b0452fb9cb1de895a9  target/x86_64-unknown-linux-musl/release/asdf
 ```
 
 If you get the same checksum you've successfully reproduced the binary. If

--- a/writeups/dockerfile.md
+++ b/writeups/dockerfile.md
@@ -1,19 +1,45 @@
 # `Dockerfile`
 
 ```dockerfile
+FROM docker.io/rust@sha256:8463cc29a3187a10fc8bf5200619aadf78091b997b0c3941345332a931c40a64
+WORKDIR /app
+COPY . .
+RUN cargo build --release --locked --target=x86_64-unknown-linux-musl
+
 FROM docker.io/alpine@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e9796141b1d379ae
-COPY target/x86_64-unknown-linux-musl/release/asdf /asdf
+COPY --from=0 /app/target/x86_64-unknown-linux-musl/release/asdf /asdf
 ENTRYPOINT ["/asdf"]
 ```
 
+The Dockerfile has two stages, the first one compiles the source code:
+
+- `FROM
+  docker.io/rust@sha256:8463cc29a3187a10fc8bf5200619aadf78091b997b0c3941345332a931c40a64`
+  This describes the image we use to build the binary for our Docker image.
+  This is the same image we also referenced in the Makefile.
+- `WORKDIR /app` By default the working directory is `/`, this line creates a
+  folder that we're going to compile in and change the working directory to
+  this folder.
+- `COPY . .` This copies the content of the current directory of the build
+  system into the container. The current dirctory on the build system is
+  expected to be the folder that this repository was cloned to, so the files
+  that are copied are only those from the git repository.
+- `RUN cargo build --release --locked --target=x86_64-unknown-linux-musl` This
+  compiles the rust source code into a binary. The command is explained in
+  detail in the [`Makefile`](makefile.md) writeup. This commnand is likely making our temporary
+
+The temporary build image is done at this point, the second `FROM` starts a new
+image:
+
 - `FROM
   docker.io/alpine@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e9796141b1d379ae`
-  This describes the image we use as a base. We're pinning one of the official
+  This is the base image for our final image that we're going to upload. The
+  rust compiler is not required anymore so we're using one of the official
   [alpine](https://hub.docker.com/_/alpine) images here.
-- `COPY target/x86_64-unknown-linux-musl/release/asdf /asdf` This copies the
-  file `target/x86_64-unknown-linux-musl/release/asdf` from our local
-  filesystem to `/asdf` in the container. See the [`Makefile`](makefile.md) how
-  this file is generated.
+- `COPY --from=0 /app/target/x86_64-unknown-linux-musl/release/asdf /asdf` This
+  copies the build artifact from the previous image into the final Docker
+  image. If this binary is reproducible the final Docker image is going to be
+  reproducible too.
 - `ENTRYPOINT ["/asdf"]` This sets the `/asdf` binary we just copied into the
   container as the entrypoint, meaning if the container is executed, this
   binary runs, nothing else.

--- a/writeups/makefile.md
+++ b/writeups/makefile.md
@@ -6,7 +6,7 @@ explain this in depth.
 ```make
 build:
 	docker run --rm -v "$(PWD):/app" -w /app -u "$(shell id -u):$(shell id -g)" \
-		rust@sha256:8463cc29a3187a10fc8bf5200619aadf78091b997b0c3941345332a931c40a64
+		rust@sha256:8463cc29a3187a10fc8bf5200619aadf78091b997b0c3941345332a931c40a64 \
 		cargo build --release --locked --target=x86_64-unknown-linux-musl
 
 docker:


### PR DESCRIPTION
This cherry-picks fixes by @bureado from #1. Since the docker image was also affected this PR updates the docker instructions and documentation build the binary inside the docker file itself instead of using it from the previous section that was built with make.